### PR TITLE
Fix unused variable warnings in the cpp headers

### DIFF
--- a/include/complex_bessel_bits/besselFunctions.h
+++ b/include/complex_bessel_bits/besselFunctions.h
@@ -186,7 +186,7 @@ inline std::complex<double> besselI(double order, std::complex<double> z)
     double s = sin_pi(nu);
 
     // We evaluate the besselK function.
-    int kodeK(1), NK(1), nzK, ierrK;
+    int nzK, ierrK;
     double cyrK, cyiK;
 
     // External function call.

--- a/include/complex_bessel_bits/sph_besselFunctions.h
+++ b/include/complex_bessel_bits/sph_besselFunctions.h
@@ -26,7 +26,7 @@ namespace sp_bessel {
 /// Near \f$z\rightarrow0\f$, the floating point division necessary would
 /// destroy precision. We thus use an ascending series to compute sph_besselJ.
 /// See \cite ABR65 Sec. 10.1.2.
-inline std::complex<double> sph_besselJ_asc_series(double order, std::complex<double> z)
+inline std::complex<double> sph_besselJ_asc_series(double, std::complex<double>)
 {
   return 0;
 }


### PR DESCRIPTION
Hi,
this PR should fix a couple of unused variable warnings in the cpp headers.