### PR TITLE
Expose errors in the underlying FORTRAN code to C++

### DIFF
--- a/include/complex_bessel.h
+++ b/include/complex_bessel.h
@@ -7,7 +7,7 @@
  * \author Denis Gagnon <gagnon88@gmail.com>
  *
  * \date 2014-01-13
- * 
+ *
  * \since 2012-09-07
  *
  * \brief Header file that includes the library headers.
@@ -20,6 +20,7 @@
  * \copyright LGPL.
  */
 
+#include "complex_bessel_bits/errors.h"
 #include "complex_bessel_bits/fortranLinkage.h"
 #include "complex_bessel_bits/utilities.h"
 #include "complex_bessel_bits/besselFunctions.h"

--- a/include/complex_bessel_bits/errors.h
+++ b/include/complex_bessel_bits/errors.h
@@ -1,0 +1,96 @@
+/*! \file errors.h
+ *
+ * \author Joey Dumont <joey.dumont@gmail.com>
+ * \author Denis Gagnon <gagnon88@gmail.com>
+ *
+ * \brief Definition of the functions computing the Bessel functions.
+ *
+ * Defines structs to hold error codes and error messages in the computation
+ * of error functions.
+ *
+ * \copyright LGPL
+ */
+
+#ifndef ERRORS_H
+#define ERRORS_H
+
+#include <unordered_map>
+#include <string>
+
+
+// Error handling main code inspired by this: https://stackoverflow.com/questions/47841783/is-there-any-advantage-in-using-stdoptional-to-avoid-default-arguments-in-a-fu
+enum ErrorCode {
+  Success,
+  InputError,
+  Overflow,
+  PartialLossOfSignificance,
+  FullLossOfSignificance,
+  AlgorithmTermination
+};
+
+typedef struct BesselErrors {
+  ErrorCode     errorCode;     // Equivalent of IERR in the original FORTRAN.
+  std::string   errorMessage;  // Error message associated with the error.
+} BesselErrors;
+
+static const std::unordered_map<std::string, std::array<BesselErrors,6>> errorMessages =
+{
+  {"besselJ", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, Im(z) too large for scale=false"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }},
+  {"besselY", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, order is too large or abs(z) is too small or both"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }},
+  {"besselI", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, Re(z) too large for scale=false"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }},
+  {"besselK", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, order is too large or abs(z) is too small or both"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }},
+  {"hankelH", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, order is too large or abs(z) too small or both"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }},
+  {"airy", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, Re(2/3*z*sqrt(z)) too large for scale=false"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }},
+  {"biry", std::array<BesselErrors,6>{
+    BesselErrors { Success,                   "Normal return        -- Computation completed." },
+    BesselErrors { InputError,                "Input error          -- No computation"},
+    BesselErrors { Overflow,                  "Overflow             -- No computation, Re(z) too large for scale=false"},
+    BesselErrors { PartialLossOfSignificance, "Loss of significance -- abs(z) large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy"},
+    BesselErrors { FullLossOfSignificance,    "Loss of significance -- abs(z) too large\n no computation because of complete loss of significance by argument reduction"},
+    BesselErrors { AlgorithmTermination,      "Error                -- no computation, algorithm termination condition not met"}
+  }}
+};
+
+#endif // ERRORS_H

--- a/include/complex_bessel_bits/fortranLinkage.h
+++ b/include/complex_bessel_bits/fortranLinkage.h
@@ -58,7 +58,7 @@ extern void zbesh_wrap(double,double,double,int,int,int,double*,double*,int*,int
 extern void zairy_wrap(double,double,int,int,double*,double*,int*,int*);
 
 /*! Airy function of the second kind. */
-extern void zbiry_wrap(double,double,int,int,double*,double*,int*,int*);
+extern void zbiry_wrap(double,double,int,int,double*,double*,int*);
 }
 ///@}
 

--- a/tests/0014.cpp
+++ b/tests/0014.cpp
@@ -1,6 +1,7 @@
 #include <complex_bessel.h>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <vector>
 
 using namespace std::complex_literals;
 using namespace sp_bessel;
@@ -11,6 +12,7 @@ public:
   }
 
   BesselErrors besselErrors;
+  std::vector<BesselErrors> besselErrors_vec;
 
 protected:
   void SetUp() override {}
@@ -51,6 +53,12 @@ TEST_F(BesselErrorsTest, AllFunctionsSuccess) {
   biry(z, 0, false, &besselErrors);
   EXPECT_EQ(0, besselErrors.errorCode);
   EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  besselJp(0, z, 1, &besselErrors_vec);
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(0, element.errorCode);
+  }
 }
 
 TEST_F(BesselErrorsTest, besselJOverflow) {
@@ -61,12 +69,35 @@ TEST_F(BesselErrorsTest, besselJOverflow) {
   EXPECT_EQ("Overflow             -- No computation, Im(z) too large for scale=false", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselJpOverflow) {
+  auto z = std::complex<double>(1000.0,1000.0);
+
+  besselJp(0, z, 1, &besselErrors_vec);
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(2, element.errorCode);
+    EXPECT_EQ("Overflow             -- No computation, Im(z) too large for scale=false", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, besselJPartialLossOfSignificance) {
   auto z = std::complex<double>(35000.0,0.0);
 
   besselJ(0, z, false, &besselErrors);
   EXPECT_EQ(3, besselErrors.errorCode);
   EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselJpPartialLossOfSignificance) {
+  auto z = std::complex<double>(35000.0,0.0);
+
+  besselJp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(3, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", element.errorMessage);
+  }
 }
 
 TEST_F(BesselErrorsTest, besselJFulllLossOfSignificance) {
@@ -77,10 +108,22 @@ TEST_F(BesselErrorsTest, besselJFulllLossOfSignificance) {
   EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselJpFulllLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+
+  besselJp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(4, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", element.errorMessage);
+  }
+}
+
 // Not sure how to trigger this error...
 // TEST_F(BesselErrorsTest, besselJAlgorithmTermination) {
 //   auto z = std::complex<double>(1'500'000'000.0,0.0);
-// 
+//
 //   besselJ(0, z, false, &besselErrors);
 //   EXPECT_EQ(5, besselErrors.errorCode);
 //   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
@@ -93,16 +136,51 @@ TEST_F(BesselErrorsTest, besselYOverflow) {
   EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) is too small or both", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselYpOverflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  besselYp(300,z,1,&besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(2, element.errorCode);
+    EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) is too small or both", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, besselYPartialLossOfSignificance) {
   auto z = std::complex<double>(35'000.0,0.0);
   besselY(0, z, false, &besselErrors);
   EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselYpPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  besselYp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(3, besselErrors.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", element.errorMessage);
+  }
 }
 
 TEST_F(BesselErrorsTest, besselYFullLossOfSignificance) {
   auto z = std::complex<double>(1'500'000'000.0,0.0);
   besselY(0, z, false, &besselErrors);
   EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselYpFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  besselYp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(4, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", element.errorMessage);
+  }
 }
 
 // Not sure how to trigger this error...
@@ -121,6 +199,17 @@ TEST_F(BesselErrorsTest, besselIOverflow) {
   EXPECT_EQ("Overflow             -- No computation, Re(z) too large for scale=false", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselIpOverflow) {
+  auto z = std::complex<double>(1'000.0,10.0);
+  besselIp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(2, element.errorCode);
+    EXPECT_EQ("Overflow             -- No computation, Re(z) too large for scale=false", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, besselIPartialLossOfSignificance) {
   auto z = std::complex<double>(0.0,35'000.0);
   besselI(0, z, false, &besselErrors);
@@ -128,11 +217,33 @@ TEST_F(BesselErrorsTest, besselIPartialLossOfSignificance) {
   EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselIpPartialLossOfSignificance) {
+  auto z = std::complex<double>(0.0,35'000.0);
+  besselIp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(3, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, besselIFullLossOfSignificance) {
   auto z = std::complex<double>(0.0,1'500'000'000.0);
   besselI(0, z, false, &besselErrors);
   EXPECT_EQ(4, besselErrors.errorCode);
   EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselIpFullLossOfSignificance) {
+  auto z = std::complex<double>(0.0,1'500'000'000.0);
+  besselIp(0, z, 1, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(4, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", element.errorMessage);
+  }
 }
 
 // Not sure how to trigger this error...
@@ -151,6 +262,17 @@ TEST_F(BesselErrorsTest, besselKOverflow) {
   EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) is too small or both", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselKpOverflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  besselKp(300, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(2, element.errorCode);
+    EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) is too small or both", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, besselKPartialLossOfSignificance) {
   auto z = std::complex<double>(35'000.0,0.0);
   besselK(0, z, false, &besselErrors);
@@ -158,11 +280,33 @@ TEST_F(BesselErrorsTest, besselKPartialLossOfSignificance) {
   EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, besselKpPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  besselKp(0, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(3, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, besselKFullLossOfSignificance) {
   auto z = std::complex<double>(1'500'000'000.0,0.0);
-  besselI(0, z, false, &besselErrors);
+  besselK(0, z, false, &besselErrors);
   EXPECT_EQ(4, besselErrors.errorCode);
   EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselKpFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  besselKp(0, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(4, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", element.errorMessage);
+  }
 }
 
 // Not sure how to trigger this error...
@@ -181,11 +325,33 @@ TEST_F(BesselErrorsTest, hankelH1Overflow) {
   EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) too small or both", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, hankelH1pOverflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  hankelH1p(300, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(2, element.errorCode);
+    EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) too small or both", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, hankelH1PartialLossOfSignificance) {
   auto z = std::complex<double>(35'000.0,0.0);
   hankelH1(0, z, false, &besselErrors);
   EXPECT_EQ(3, besselErrors.errorCode);
   EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, hankelH1pPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  hankelH1p(0, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(3, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", element.errorMessage);
+  }
 }
 
 TEST_F(BesselErrorsTest, hankelH1FullLossOfSignificance) {
@@ -194,6 +360,18 @@ TEST_F(BesselErrorsTest, hankelH1FullLossOfSignificance) {
   EXPECT_EQ(4, besselErrors.errorCode);
   EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
 }
+
+TEST_F(BesselErrorsTest, hankelH1pFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  hankelH1p(0, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(4, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", element.errorMessage);
+  }
+}
+
 
 // Not sure how to trigger this error...
 // TEST_F(BesselErrorsTest, hankelH1AlgorithmTermination) {
@@ -211,6 +389,17 @@ TEST_F(BesselErrorsTest, hankelH2Overflow) {
   EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) too small or both", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, hankelH2pOverflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  hankelH2p(300, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(2, element.errorCode);
+    EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) too small or both", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, hankelH2PartialLossOfSignificance) {
   auto z = std::complex<double>(35'000.0,0.0);
   hankelH2(0, z, false, &besselErrors);
@@ -218,11 +407,33 @@ TEST_F(BesselErrorsTest, hankelH2PartialLossOfSignificance) {
   EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
 }
 
+TEST_F(BesselErrorsTest, hankelH2pPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  hankelH2p(0, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(3, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", element.errorMessage);
+  }
+}
+
 TEST_F(BesselErrorsTest, hankelH2FullLossOfSignificance) {
   auto z = std::complex<double>(1'500'000'000.0,0.0);
   hankelH2(0, z, false, &besselErrors);
   EXPECT_EQ(4, besselErrors.errorCode);
   EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, hankelH2pFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  hankelH2p(0, z, false, &besselErrors_vec);
+
+  for (auto element : besselErrors_vec)
+  {
+    EXPECT_EQ(4, element.errorCode);
+    EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", element.errorMessage);
+  }
 }
 
 // Not sure how to trigger this error...
@@ -288,7 +499,7 @@ TEST_F(BesselErrorsTest, biryFullLossOfSignificance) {
 }
 
 // Not sure how to trigger this error...
-// TEST_F(BesselErrorsTest, airyAlgorithmTermination) {
+// TEST_F(BesselErrorsTest, biryAlgorithmTermination) {
 //   auto z = std::complex<double>(1'500'000'000.0,0.0);
 //   besselK(0, z, false, &besselErrors);
 //   EXPECT_EQ(5, besselErrors.errorCode);

--- a/tests/0014.cpp
+++ b/tests/0014.cpp
@@ -1,0 +1,302 @@
+#include <complex_bessel.h>
+#include <gtest/gtest.h>
+#include <iostream>
+
+using namespace std::complex_literals;
+using namespace sp_bessel;
+
+class BesselErrorsTest : public ::testing::Test {
+public:
+  BesselErrorsTest() {
+  }
+
+  BesselErrors besselErrors;
+
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(BesselErrorsTest, AllFunctionsSuccess) {
+  auto z = std::complex<double>(1.0,0.0);
+
+  besselJ(0, z, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  besselY(0, z, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  besselK(0, z, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  besselI(0, z, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  hankelH1(0, z, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  hankelH2(0, z, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  airy(z, 0, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+
+  biry(z, 0, false, &besselErrors);
+  EXPECT_EQ(0, besselErrors.errorCode);
+  EXPECT_EQ("Normal return        -- Computation completed.", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselJOverflow) {
+  auto z = std::complex<double>(1000.0,1000.0);
+
+  besselJ(0, z, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, Im(z) too large for scale=false", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselJPartialLossOfSignificance) {
+  auto z = std::complex<double>(35000.0,0.0);
+
+  besselJ(0, z, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselJFulllLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+
+  besselJ(0, z, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, besselJAlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+// 
+//   besselJ(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+// }
+
+TEST_F(BesselErrorsTest, besselYOverflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  besselY(300,z,false,&besselErrors);
+  EXPECT_EQ(2,besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) is too small or both", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselYPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  besselY(0, z, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+}
+
+TEST_F(BesselErrorsTest, besselYFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  besselY(0, z, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, besselYAlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   besselY(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+TEST_F(BesselErrorsTest, besselIOverflow) {
+  auto z = std::complex<double>(1'000.0,10.0);
+  besselI(0, z, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, Re(z) too large for scale=false", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselIPartialLossOfSignificance) {
+  auto z = std::complex<double>(0.0,35'000.0);
+  besselI(0, z, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselIFullLossOfSignificance) {
+  auto z = std::complex<double>(0.0,1'500'000'000.0);
+  besselI(0, z, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, besselIAlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   besselI(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+TEST_F(BesselErrorsTest, besselKOverflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  besselK(300, z, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) is too small or both", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselKPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  besselK(0, z, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, besselKFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  besselI(0, z, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, besselKAlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   besselK(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+TEST_F(BesselErrorsTest, hankelH1Overflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  hankelH1(300, z, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) too small or both", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, hankelH1PartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  hankelH1(0, z, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, hankelH1FullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  hankelH1(0, z, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, hankelH1AlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   hankelH1(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+TEST_F(BesselErrorsTest, hankelH2Overflow) {
+  auto z = std::complex<double>(10.0,10.0);
+  hankelH2(300, z, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, order is too large or abs(z) too small or both", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, hankelH2PartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  hankelH2(0, z, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, hankelH2FullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  hankelH2(0, z, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) or order too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, hankelH2AlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   hankelH2(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+TEST_F(BesselErrorsTest, airyOverflow) {
+  auto z = std::complex<double>(-1'000.0,1'000.0);
+  airy(z, 0, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, Re(2/3*z*sqrt(z)) too large for scale=false", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, airyPartialLossOfSignificance) {
+  auto z = std::complex<double>(35'000.0,0.0);
+  airy(z, 0, false, &besselErrors);
+  EXPECT_EQ(3, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+}
+
+TEST_F(BesselErrorsTest, airyFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  airy(z, 0, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, airyAlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   besselK(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+TEST_F(BesselErrorsTest, biryOverflow) {
+  auto z = std::complex<double>(10'000.0,0.0);
+  biry(z, 0, false, &besselErrors);
+  EXPECT_EQ(2, besselErrors.errorCode);
+  EXPECT_EQ("Overflow             -- No computation, Re(z) too large for scale=false", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error. It returns the overflow error, then switches
+// to full loss of significance. Should test against more precise library.
+//TEST_F(BesselErrorsTest, biryPartialLossOfSignificance) {
+//  auto z = std::complex<double>(1'000'000,100.0);
+//  biry(z, 0, false, &besselErrors);
+//  EXPECT_EQ(3, besselErrors.errorCode);
+//  EXPECT_EQ("Loss of significance -- abs(z) large \n computation done but losses of significance by argument reduction produce less than half of machine accuracy", besselErrors.errorMessage);
+//}
+
+TEST_F(BesselErrorsTest, biryFullLossOfSignificance) {
+  auto z = std::complex<double>(1'500'000'000.0,0.0);
+  biry(z, 0, false, &besselErrors);
+  EXPECT_EQ(4, besselErrors.errorCode);
+  EXPECT_EQ("Loss of significance -- abs(z) too large\n no computation because of complete loss of significance by argument reduction", besselErrors.errorMessage);
+}
+
+// Not sure how to trigger this error...
+// TEST_F(BesselErrorsTest, airyAlgorithmTermination) {
+//   auto z = std::complex<double>(1'500'000'000.0,0.0);
+//   besselK(0, z, false, &besselErrors);
+//   EXPECT_EQ(5, besselErrors.errorCode);
+//   EXPECT_EQ("Error                -- no computation, algorithm termination condition not met", besselErrors.errorMessage);
+//
+// }
+
+int main (int argc, char *argv[]) {
+  testing::InitGoogleTest(&argc,argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,3 +38,10 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 target_link_libraries("0012" ${PROJECT_NAME})
 target_link_libraries("0012" ${LIBS})
 add_test(NAME "0012" COMMAND "0012")
+
+# -- Output tests in directory
+add_executable("0014" "0014.cpp")
+include_directories(${CMAKE_SOURCE_DIR}/include)
+target_link_libraries("0014" ${PROJECT_NAME})
+target_link_libraries("0014" ${LIBS})
+add_test(NAME "0014" COMMAND "0014")


### PR DESCRIPTION
This PR makes the error messages from FORTRAN accessible to the C++ code.

The error is returned in a separate object, which must be passed to each function. 